### PR TITLE
Improve JWT Token Validation for Audience

### DIFF
--- a/lib/devise/auth0.rb
+++ b/lib/devise/auth0.rb
@@ -27,7 +27,9 @@ module Devise
     extend ::Dry::Configurable
 
     setting(:algorithm, default: "RS256")
-    setting(:aud, default: ENV["AUTH0_AUDIENCE"].presence)
+    setting(:aud,
+      default: ENV["AUTH0_AUDIENCE"].presence,
+      constructor: ->(aud) { aud.is_a?(Array) ? aud : aud.to_s.split(",") })
     setting(:client_id, default: ENV["AUTH0_CLIENT_ID"].presence)
     setting(:client_secret, default: ENV["AUTH0_CLIENT_SECRET"].presence)
     setting(:domain, default: ENV["AUTH0_DOMAIN"].presence)

--- a/lib/devise/auth0/token.rb
+++ b/lib/devise/auth0/token.rb
@@ -62,7 +62,7 @@ module Devise
           algorithms: config.algorithm,
           iss: "https://#{config.domain}/",
           verify_iss: true,
-          aud: config.aud.split(","),
+          aud: config.aud,
           verify_aud: true) do |header|
           jwks_hash[header["kid"]]
         end

--- a/lib/devise/models/auth0.rb
+++ b/lib/devise/models/auth0.rb
@@ -57,7 +57,7 @@ module Devise
           ).first.try(:[], "scope")
         else
           self.class.auth0_client.get_user_permissions(auth0_id).select do |permission|
-            permission["resource_server_identifier"] == self.class.auth0_config.aud
+            self.class.auth0_config.aud.include?(permission["resource_server_identifier"])
           end.map do |permission|
             permission["permission_name"]
           end

--- a/spec/devise_spec.rb
+++ b/spec/devise_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe(Devise) do
     end
 
     it "defaults to ENV['AUTH0_AUDIENCE'] for aud" do
-      expect(config.aud).to(eq(ENV["AUTH0_AUDIENCE"]))
+      expect(config.aud).to(match_array(ENV["AUTH0_AUDIENCE"].to_s.split(",")))
     end
 
     it "defaults to ENV['AUTH0_CLIENT_ID'] for client_id" do

--- a/spec/fixtures/vcr_cassettes/auth0/grants/UDuyRC6XeVr9eCPIrOP0dgIL0xTLs33f.yml
+++ b/spec/fixtures/vcr_cassettes/auth0/grants/UDuyRC6XeVr9eCPIrOP0dgIL0xTLs33f.yml
@@ -250,4 +250,82 @@ http_interactions:
       string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImlMYVlEMFR2VjdPLW16clFXeHhxTCJ9.eyJpc3MiOiJodHRwczovL2ZpcnN0Y2lyY2xlLWRldi5ldS5hdXRoMC5jb20vIiwic3ViIjoiSVBVbFgybHB5S2xJc043QnJiZkdHVXVpaEx0SlRqUUJAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vZmlyc3RjaXJjbGUtZGV2LmV1LmF1dGgwLmNvbS9hcGkvdjIvIiwiaWF0IjoxNjQ1MDc0NTc5LCJleHAiOjE2NDUxNjA5NzksImF6cCI6IklQVWxYMmxweUtsSXNON0JyYmZHR1V1aWhMdEpUalFCIiwic2NvcGUiOiJyZWFkOmNsaWVudF9ncmFudHMgcmVhZDp1c2VycyB1cGRhdGU6dXNlcnMgZGVsZXRlOnVzZXJzIGNyZWF0ZTp1c2VycyByZWFkOmdyYW50cyIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyJ9.SQnqdCi20Jhp7BfXYqB98kmubO0b_EAxdpENnfQ_4NKFSLw0Ac7PqXiePcrREWrIdr6tHL2rBpklWISseQaXknnaciCds8lL5GNQMSMsmEZ53MFEISdOR5H4X8urUZWnLpM9hrnxkSbie-ds7p9KciqP45gQYQrlelbQE_kfQdKC8AiITr0cvoIEV2xUe-u9tV9kuYwVa6BdRu_1sDMn2eQbzl5kFUUH0xCKAHzL2gNg34VMgDY7VR2HHDNajCrocQ6_3DjhGajgBhKDAzGJBERJxWtIEwBszPQIvOqNtDEJPlFIjvE-owQwuKT3AwsZTnmAyOTgJDfQlJfZu9UPqg","scope":"read:client_grants
         read:users update:users delete:users create:users read:grants","expires_in":86400,"token_type":"Bearer"}'
   recorded_at: Thu, 17 Feb 2022 05:09:39 GMT
+- request:
+    method: get
+    uri: https://[AUTH0_DOMAIN]/api/v2/client-grants?audience%5B%5D=[AUTH0_AUDIENCE]&client_id=UDuyRC6XeVr9eCPIrOP0dgIL0xTLs33f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.5p114
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjYuMSIsImVudiI6eyJydWJ5IjoiMi42LjUiLCJyYWlscyI6IjYuMS40LjYifX0=
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImlMYVlEMFR2VjdPLW16clFXeHhxTCJ9.eyJpc3MiOiJodHRwczovL2ZpcnN0Y2lyY2xlLWRldi5ldS5hdXRoMC5jb20vIiwic3ViIjoiSVBVbFgybHB5S2xJc043QnJiZkdHVXVpaEx0SlRqUUJAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vZmlyc3RjaXJjbGUtZGV2LmV1LmF1dGgwLmNvbS9hcGkvdjIvIiwiaWF0IjoxNjQ2MDI3Mzc5LCJleHAiOjE2NDYxMTM3NzksImF6cCI6IklQVWxYMmxweUtsSXNON0JyYmZHR1V1aWhMdEpUalFCIiwic2NvcGUiOiJyZWFkOmNsaWVudF9ncmFudHMgcmVhZDp1c2VycyB1cGRhdGU6dXNlcnMgZGVsZXRlOnVzZXJzIGNyZWF0ZTp1c2VycyByZWFkOmdyYW50cyBkZWxldGU6Z3JhbnRzIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.dJK3A86PfdWXG7uX7ajOu2Ka1o_Jm0Gxdqey6aeAgmKM-hDOfBLhKpXiICW2YKfFueznBwKawM80AKXhgbJ3c0-Fc7D4WLV9QYS3MzYltL0EpB2UTj9hArVqmkU78IuGNeQ1Onl1xPj2MUa8qKFVTkPxbsdNEwvvzVqItEj-4G90vQQ6PVSGwlfOxJR0mUFQ9XN4NOi1IPEc_Wn6AFanVxvgN798RelaqIwVmfzmEwR68BpqEVXHBDZB_XDygZNqn7IfCSkD_ctBVJ2yRuJOGdeb0-arwXO0jAKjhzzFoZdu_mkqIL1rkan0TuqOe_lMVjj4dp33KnLyTcPU5Y0LzQ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - "[AUTH0_DOMAIN]"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 28 Feb 2022 09:36:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 6e48abc1ee2a6bf7-SIN
+      Cache-Control:
+      - no-cache
+      Link:
+      - <http://[AUTH0_DOMAIN]/api/v2/client-grants?client_id=UDuyRC6XeVr9eCPIrOP0dgIL0xTLs33f&audience%5B%5D=https%3A%2F%2Frails-api-auth-sample.firstcircle.io&page=0&per_page=50>;
+        rel="first", <http://[AUTH0_DOMAIN]/api/v2/client-grants?client_id=UDuyRC6XeVr9eCPIrOP0dgIL0xTLs33f&audience%5B%5D=https%3A%2F%2Frails-api-auth-sample.firstcircle.io&page=0&per_page=50>;
+        rel="last"
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6e48abc1ee2a6bf7
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - '038688ee0f256003'
+      Ot-Tracer-Traceid:
+      - 7995fc920d405539
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1646041014'
+      Set-Cookie:
+      - __cf_bm=RhpYRQ2AOJ0WxaEi86jEXbupxgBOn6Dg6mZrXAuLrK8-1646041013-0-AQZN0H41afQAclrCfdLJmokNXEeMWsnFldxkT82BY218ChRPm+ODuFXk/6dX4szMNLB7XN/DZIbJ8XWE/p36X24=;
+        path=/; expires=Mon, 28-Feb-22 10:06:53 GMT; domain=.eu.auth0.com; HttpOnly;
+        Secure; SameSite=None
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"cgr_ieSlnMwtPDgFnTmA","client_id":"UDuyRC6XeVr9eCPIrOP0dgIL0xTLs33f","audience":"[AUTH0_AUDIENCE]","scope":["read:leads"]}]'
+  recorded_at: Mon, 28 Feb 2022 09:36:53 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
### Changes

This improves the validation of the JWT token with the audience by allowing it to be an array of audience.

### References

- [Audience Claim](https://github.com/jwt/ruby-jwt/tree/8a84340c39a9714c70ea99b021710da3932f6aa8#audience-claim)
- [JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519#section-4.1.3)

Please note any links that are not publicly accessible.

### Testing

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed